### PR TITLE
fixed python install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ install:
   # Packages for testing
   - conda install pytest
   # Install WPS
-  - python setup.py develop
+  - python setup.py install
 script:
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: pytest_fun
+channels:
+- defaults
+dependencies:
+- numpy
+# tests
+- pytest

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ def readme():
 
 
 def pip_requirements(fname='requirements.txt'):
+    reqs = []
     with open(fname, 'r') as f:
         for line in f:
             line = line.strip()
@@ -17,11 +18,8 @@ def pip_requirements(fname='requirements.txt'):
     return reqs
 
 
-reqs = [line.strip() for line in open('requirements.txt')]
-
-
 setup(
-    name="pytest-fun",
+    name="pytest_fun",
     version=0.2,
     description="Pytest Training",
     long_description=readme(),


### PR DESCRIPTION
This PR fixes the python installation. `__init__.py` was missing in package folder.

Fix #23.